### PR TITLE
fix(KeyManager): make _derivedPriv method private to prevent key extraction

### DIFF
--- a/src/KeyManager.sol
+++ b/src/KeyManager.sol
@@ -38,7 +38,7 @@ abstract contract KeyManagerBase {
     
     // Any contract in confidential mode can request a
     // hardened derived key
-    function _derivedPriv(address a) public returns (bytes32) {
+    function _derivedPriv(address a) private returns (bytes32) {
         return keccak256(abi.encodePacked(a, xPriv()));
     }
 


### PR DESCRIPTION
If `_derivedPriv` is public, I can call it from any contract and leak the private key for all contracts by returning it as a value. Should be private, right?