### PR TITLE
fix Auction.t.sol: set block.height  > auctionEndTime before calling *_Finalize()

### DIFF
--- a/test/examples/Auction.t.sol
+++ b/test/examples/Auction.t.sol
@@ -64,7 +64,7 @@ contract SealedAuctionTest is Test {
         vm.prank(bob);
         auc.submitEncrypted(bBid);
 
-        vm.roll(3);
+        vm.roll(4);
 
         // Off chain compute the solution
         (uint256 secondPrice, bytes memory sig2) = auc.offchain_Finalize();


### PR DESCRIPTION
as is they are equal and this test will revert (is this intended?)

```bash
    ├─ [1177] SealedAuction::offchain_Finalize()
    │   ├─ [0] console::log(" block.height%d:  auctionEndTime: %d", 3, 3) [staticcall]
    │   │   └─ ← ()
    │   └─ ← EvmError: Revert
    └─ ← EvmError: Revert
```