### PR TITLE
 HTTPS precompile and example

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -1,19 +1,24 @@
 {
   "RPC_URL": "https://rpc.rigil.suave.flashbots.net",
-  "KETTLE_RPC": "http://kettle.sirrah.suave.flashbots.net:5556",
-  "PRIVATE_KEY": "",
+  "KETTLE_RPC": "http://10.0.232.31:5556",
+  "PRIVATE_KEY": "0x268af2ad1951e7898bf1c4f1e1c6775dc13a6231fb1c54cfd9d45a214c712c03",
   "TCB_INFO_FILE": "lib/automata-dcap-v3-attestation/contracts/assets/tcbInfo2.json",
   "QE_IDENTITY_FILE": "lib/automata-dcap-v3-attestation/contracts/assets/identity.json",
   "SIGVERIFY_LIB_ARTIFACT": "out/SigVerifyLib.sol/SigVerifyLib.json",
   "ANDROMEDA_ARTIFACT": "out/Andromeda.sol/Andromeda.json",
+  "HTTPCALL_ARTIFACT": "out/httpcall.sol/HTTP.json",
   "TRUSTED_MRENCLAVES": [
-    "0xa9956056f8f39fffbe148eeb0285be7dc8a9034fd393d5f62a7b058c6ad5e82b"
+    "0xbcfbf5f9522b2390005704ec3a672a83f73ffbe143b0c179ca7c4f741633a4cc"
   ],
   "TRUSTED_MRSIGNERS": [
-    "0xf0365ce7081fda379914c703fe08648db1cce3747e8c10f74ff742926399f15a"
+    "0xd1e46f2f04cb4d5c774bf97312c7cda09dd0115e08c81f41e1b01b9a50e09d6d"
   ],
   "KEY_MANAGER_SN_ARTIFACT": "out/KeyManager.sol/KeyManager_v0.json",
   "SEALED_AUCTION_ARTIFACT": "out/Auction.sol/SealedAuction.json",
   "TIMELOCK_ARTIFACT": "out/Timelock.sol/Timelock.json",
-  "ADDR_OVERRIDES": {}
+  "ADDR_OVERRIDES": {
+    "out/SigVerifyLib.sol/SigVerifyLib.json": "0xfeA20757E06637CC8A03a0Fd53fDAB87FE4dE04A",
+    "out/Andromeda.sol/Andromeda.json": "0x1e5Bf2B3871828a9d17996fB1aDBD322dE371F69",
+    "out/KeyManager.sol/KeyManager_v0.json": "0xDa382e2F9684F269CC97368FFEFd719b19E20858"
+  }
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -17,6 +17,10 @@ async function deploy() {
   const [Andromeda, andomedaFound] = await deploy_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, SigVerifyLib.target);
 
   if (andomedaFound) { 
+    for (let i = 0; i < LocalConfig.TRUSTED_MRENCLAVES.length; i++) {
+      const tx = await (await Andromeda.setMrEnclave(LocalConfig.TRUSTED_MRENCLAVES[i], true)).wait();
+      console.log("Set mr_enclave "+LocalConfig.TRUSTED_MRENCLAVES[i]+" as trusted in "+tx.hash);
+    }
     console.log("Andromeda already deployed, not configuring it");
   } else {
     const enclaveId = JSON.parse(fs.readFileSync(LocalConfig.QE_IDENTITY_FILE, 'utf8')) as EnclaveIdStruct.EnclaveIdStruct;

--- a/src/Andromeda.sol
+++ b/src/Andromeda.sol
@@ -14,6 +14,13 @@ contract Andromeda is IAndromeda, DcapDemo {
     address public constant VOLATILEGET_ADDR = 0x0000000000000000000000000000000000040702;
     address public constant RANDOM_ADDR = 0x0000000000000000000000000000000000040703;
     address public constant SEALINGKEY_ADDR = 0x0000000000000000000000000000000000040704;
+    address public constant HTTP_ADDR = 0x0000000000000000000000000000000000040705;
+
+    function httpCall(string memory url) external view override returns (string memory) {
+        (bool success, bytes memory response) = HTTP_ADDR.staticcall(bytes(url));
+        require(success);
+        return string(response);
+    }
 
     function volatileSet(bytes32 key, bytes32 value) external override {
         bytes memory cdata = abi.encodePacked([key, value]);
@@ -37,7 +44,7 @@ contract Andromeda is IAndromeda, DcapDemo {
 
     function verifySgx(address caller, bytes32 appData, bytes memory att) public view returns (bool) {
         bytes memory userdata = abi.encode(address(this), abi.encodePacked(caller, appData));
-        bytes memory userReport = abi.encodePacked(sha256(userdata), uint(0));
+        bytes memory userReport = abi.encodePacked(sha256(userdata), uint256(0));
         (,, V3Struct.EnclaveReport memory r,,) = V3Parser.parseInput(att);
         if (keccak256(r.reportData) != keccak256(userReport)) {
             return false;

--- a/src/AndromedaForge.sol
+++ b/src/AndromedaForge.sol
@@ -63,6 +63,10 @@ contract AndromedaForge is IAndromeda {
         return vm.envOr(env, bytes32(""));
     }
 
+    function httpCall(string memory url) external view override returns (string memory) {
+        return "";
+    }
+
     // Currently active host
     string activeHost = "default";
 

--- a/src/AndromedaRemote.sol
+++ b/src/AndromedaRemote.sol
@@ -26,21 +26,15 @@ interface Vm {
 }
 
 contract Tester {
-    function configureQeIdentityJson(
-        EnclaveIdStruct.EnclaveId calldata qeIdentityInput
-    ) public {
-	//console2.log("configureQeIdentityJson");
+    function configureQeIdentityJson(EnclaveIdStruct.EnclaveId calldata qeIdentityInput) public {
+        //console2.log("configureQeIdentityJson");
         //console2.logBytes(msg.data);
     }
-    
-    function configureTcbInfoJson(
-        string calldata fmspc,
-        TCBInfoStruct.TCBInfo calldata tcbInfoInput
-    ) public {
-	//console2.log("configureTcbInfoJson");
+
+    function configureTcbInfoJson(string calldata fmspc, TCBInfoStruct.TCBInfo calldata tcbInfoInput) public {
+        //console2.log("configureTcbInfoJson");
         //console2.logBytes(msg.data);
     }
-    
 }
 
 contract AndromedaRemote is IAndromeda, DcapDemo {
@@ -52,8 +46,8 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
     constructor(address sigVerifyLib) DcapDemo(sigVerifyLib) {}
 
     function initialize() public {
-	Tester t = new Tester();
-	
+        Tester t = new Tester();
+
         // This is the dummy enclave from the service
         // https://github.com/amiller/gramine-dummy-attester/tree/dcap
         setMrEnclave(bytes32(0xdc43f8c42d8e5f52c8bbd68f426242153f0be10630ff8cca255129a3ca03d273), true);
@@ -68,18 +62,18 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
         {
             string memory p = "test/fixtures/quotingenclave-identity.json";
             EnclaveIdStruct.EnclaveId memory s = parseIdentity(p);
-	    //console2.log('configureQeIdentityJson');
-	    //console2.logBytes(abi.encode(s));
+            //console2.log('configureQeIdentityJson');
+            //console2.logBytes(abi.encode(s));
             vm.prank(address(owner));
             this.configureQeIdentityJson(s);
-            t.configureQeIdentityJson(s);	    
+            t.configureQeIdentityJson(s);
         }
         // Load one of the TCB Infos. These are signed by Intel. But here the signature isn't checked. FIXME
         {
             TCBInfoStruct.TCBInfo memory s = parseTcbInfo("test/fixtures/tcbInfo.json");
-	    //console2.log('configureTcbInfoJson');
-	    //console2.logBytes(abi.encodePacked(s.fmspc));
-	    //console2.logBytes(abi.encode(s));
+            //console2.log('configureTcbInfoJson');
+            //console2.logBytes(abi.encodePacked(s.fmspc));
+            //console2.logBytes(abi.encode(s));
             vm.prank(address(owner));
             this.configureTcbInfoJson(s.fmspc, s);
             t.configureTcbInfoJson(s.fmspc, s);
@@ -87,10 +81,10 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
     }
 
     function attestSgx(bytes32 appData) public view returns (bytes memory) {
-	console2.log("attestSgx remote");
+        console2.log("attestSgx remote");
         bytes memory userdata = abi.encode(address(this), abi.encodePacked(msg.sender, appData));
-	console2.logBytes(userdata);
-	bytes memory userReport = abi.encodePacked(sha256(userdata), uint(0));
+        console2.logBytes(userdata);
+        bytes memory userReport = abi.encodePacked(sha256(userdata), uint256(0));
         string[] memory inputs = new string[](3);
         inputs[0] = "python";
         inputs[1] = "ffi/ffi-fetchquote-dcap.py";
@@ -100,10 +94,10 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
     }
 
     function verifySgx(address caller, bytes32 appData, bytes memory att) public view returns (bool) {
-	console2.log("verifySgx remote");
-	//console2.logBytes(att);
+        console2.log("verifySgx remote");
+        //console2.logBytes(att);
         bytes memory userdata = abi.encode(address(this), abi.encodePacked(caller, appData));
-	bytes memory userReport = abi.encodePacked(sha256(userdata), uint(0));
+        bytes memory userReport = abi.encodePacked(sha256(userdata), uint256(0));
         (,, V3Struct.EnclaveReport memory r,,) = V3Parser.parseInput(att);
         if (keccak256(r.reportData) != keccak256(userReport)) {
             return false;
@@ -143,6 +137,10 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
         address caller = msg.sender;
         string memory env = toEnv(activeHost, caller, tag);
         return vm.envOr(env, bytes32(""));
+    }
+
+    function httpCall(string memory url) external view returns (string memory) {
+        return "";
     }
 
     // Currently active host

--- a/src/IAndromeda.sol
+++ b/src/IAndromeda.sol
@@ -10,4 +10,5 @@ interface IAndromeda {
     function volatileGet(bytes32 tag) external returns (bytes32);
     function localRandom() external view returns (bytes32);
     function sealingKey(bytes32 tag) external view returns (bytes32);
+    function httpCall(string memory url) external view returns (string memory);
 }

--- a/src/examples/httpcall.sol
+++ b/src/examples/httpcall.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.8.13;
+
+import "../crypto/secp256k1.sol";
+import "../crypto/encryption.sol";
+import "../KeyManager.sol";
+
+contract HTTP {
+    KeyManager_v0 keymgr;
+    address public constant HTTP_ADDR = 0x0000000000000000000000000000000000040705;
+
+
+    constructor(KeyManager_v0 _keymgr) {
+        keymgr = _keymgr;
+    }
+
+    /*
+    To initialize, some Kettle must invoke:
+       `keymgr.offchain_DeriveKey(auc) -> dPub,v,r,s`
+       `keymgr.onchain_DeriveKey(auc,dPub,v,r,s)`
+    */
+    function isInitialized() public view returns (bool) {
+        return keymgr.derivedPub(address(this)).length != 0;
+    }
+
+    function makeHttpCall() public view returns (string memory) {
+        return httpCall("https://scholar.google.com");
+    }
+
+    function httpCall(string memory url) internal view returns (string memory) {
+        (bool success, bytes memory response) = HTTP_ADDR.staticcall(bytes(url));
+        require(success);
+        // return response;
+        return string(response);
+    }
+}

--- a/src/scripts/TimelockSetup.sol
+++ b/src/scripts/TimelockSetup.sol
@@ -26,9 +26,7 @@ contract TimelockSetup2 is Script {
         console2.log("Running TimelockSetup2");
         // To ensure we don't use the same address with volatile storage
         // vm.prank(vm.addr(uint256(keccak256("examples/Timelock.t.sol"))));
-        KeyManager_v0 keymgr = new KeyManager_v0(
-            address(vm.envAddress("andromeda"))
-        );
+        KeyManager_v0 keymgr = new KeyManager_v0(address(vm.envAddress("andromeda")));
         (address xPub, bytes memory att) = keymgr.offchain_Bootstrap();
         keymgr.onchain_Bootstrap(xPub, att);
     }

--- a/test/KeyManager.t.sol
+++ b/test/KeyManager.t.sol
@@ -17,7 +17,7 @@ contract KeyManager_v0_Test is Test {
 
     function setUp() public {
         andromeda = new AndromedaForge();
-        vm.prank(vm.addr(uint(keccak256("KeyManager.t.sol"))));
+        vm.prank(vm.addr(uint256(keccak256("KeyManager.t.sol"))));
         keymgr = new KeyManager_v0(address(andromeda));
 
         alice = vm.createWallet("alice");
@@ -35,16 +35,14 @@ contract KeyManager_v0_Test is Test {
         // 2. Register a new node
         // 2a. Offchain generate a register request
         andromeda.switchHost("bob");
-        (address bob_kettle, bytes memory bPub, bytes memory attB) = keymgr
-            .offchain_Register();
+        (address bob_kettle, bytes memory bPub, bytes memory attB) = keymgr.offchain_Register();
         // 2b. Onchain submit the request
         keymgr.onchain_Register(bob_kettle, bPub, attB);
 
         // 2.1 Register a new node
         // 2.1a. Offchain generate a register request
         andromeda.switchHost("charlie");
-        (address charlie_kettle, bytes memory cPub, bytes memory attC) = keymgr
-            .offchain_Register();
+        (address charlie_kettle, bytes memory cPub, bytes memory attC) = keymgr.offchain_Register();
         // 2.1b. Onchain submit the request
         keymgr.onchain_Register(charlie_kettle, cPub, attC);
 
@@ -75,9 +73,7 @@ contract KeyManager_v0_Test is Test {
         keymgr.onchain_Bootstrap(xPub, att);
 
         // Show the derived key associated with this contract.
-        (bytes memory dPub, bytes memory sig) = keymgr.offchain_DeriveKey(
-            address(this)
-        );
+        (bytes memory dPub, bytes memory sig) = keymgr.offchain_DeriveKey(address(this));
         keymgr.onchain_DeriveKey(address(this), dPub, sig);
 
         bytes32 dPriv = keymgr.derivedPriv();

--- a/test/examples/Auction.t.sol
+++ b/test/examples/Auction.t.sol
@@ -24,8 +24,8 @@ contract SealedAuctionTest is Test {
 
         andromeda.setMrSigner(bytes32(0x1cf2e52911410fbf3f199056a98d58795a559a2e800933f7fcd13d048462271c), true);
 
-	// To ensure we don't use the same address with volatile storage
-	vm.prank(vm.addr(uint256(keccak256("examples/Auction.t.sol"))));
+        // To ensure we don't use the same address with volatile storage
+        vm.prank(vm.addr(uint256(keccak256("examples/Auction.t.sol"))));
         keymgr = new KeyManager_v0(address(andromeda));
         (address xPub, bytes memory att) = keymgr.offchain_Bootstrap();
         keymgr.onchain_Bootstrap(xPub, att);

--- a/test/examples/SpeedrunAuction.t.sol
+++ b/test/examples/SpeedrunAuction.t.sol
@@ -32,7 +32,7 @@ contract SpeedrunAuction is Test {
     }
 
     function test_sealed() public {
-        vm.prank(address(vm.addr(uint(keccak256("SpeedrunAuction.t.sol")))));
+        vm.prank(address(vm.addr(uint256(keccak256("SpeedrunAuction.t.sol")))));
         SealedAuction auc = new SealedAuction(andromeda);
 
         // Have a Kettle initialize the key

--- a/test/examples/Timelock.t.sol
+++ b/test/examples/Timelock.t.sol
@@ -23,12 +23,7 @@ contract TimelockTest is Test {
         andromeda.initialize();
         vm.warp(1701528486);
 
-        andromeda.setMrSigner(
-            bytes32(
-                0x1cf2e52911410fbf3f199056a98d58795a559a2e800933f7fcd13d048462271c
-            ),
-            true
-        );
+        andromeda.setMrSigner(bytes32(0x1cf2e52911410fbf3f199056a98d58795a559a2e800933f7fcd13d048462271c), true);
 
         // To ensure we don't use the same address with volatile storage
         vm.prank(vm.addr(uint256(keccak256("examples/Timelock.t.sol"))));
@@ -45,18 +40,13 @@ contract TimelockTest is Test {
 
         // Initialize the derived public key
         assertEq(timelock.isInitialized(), false);
-        (bytes memory dPub, bytes memory sig) = keymgr.offchain_DeriveKey(
-            address(timelock)
-        );
+        (bytes memory dPub, bytes memory sig) = keymgr.offchain_DeriveKey(address(timelock));
         keymgr.onchain_DeriveKey(address(timelock), dPub, sig);
         assertEq(timelock.isInitialized(), true);
 
         // Submit encrypted orders
         string memory message = "Suave timelock test message!32xr";
-        bytes memory ciph = timelock.encryptMessage(
-            message,
-            bytes32(uint(0xdead2123))
-        );
+        bytes memory ciph = timelock.encryptMessage(message, bytes32(uint256(0xdead2123)));
         timelock.submitEncrypted(ciph);
 
         vm.roll(60);


### PR DESCRIPTION
This PR adds a feature, including an example and an updated Andromeda.sol wrapper, for an HTTPs precompile.

See this [PR for the precompile itself.](https://github.com/flashbots/suave-andromeda-revm/pull/13/files)

w/ @sxysun and @maceip 