### PR TITLE
Seed recovery process to survive kettle restarts 

### DIFF
--- a/scripts/test_examples.ts
+++ b/scripts/test_examples.ts
@@ -97,7 +97,6 @@ async function deploy() {
 
   const SealedAuction = await deploy_artifact_direct(LocalConfig.SEALED_AUCTION_ARTIFACT, wallet, KM.target, 5);
   await kettle_advance(kettle);
-
   await derive_key(await SealedAuction.getAddress(), kettle, KM);
   await testSA(SealedAuction, kettle);
 }

--- a/src/Andromeda.sol
+++ b/src/Andromeda.sol
@@ -24,11 +24,10 @@ contract Andromeda is IAndromeda, DcapDemo {
         require(success);
     }
 
-    function volatileGet(bytes32 key) external override returns (bytes32) {
+    function volatileGet(bytes32 key) public view returns (bytes memory) {
         (bool success, bytes memory value) = VOLATILEGET_ADDR.staticcall(abi.encodePacked((key)));
         require(success);
-        require(value.length == 32);
-        return abi.decode(value, (bytes32));
+        return abi.decode(value, (bytes));
     }
 
     function attestSgx(bytes32 appData) external override returns (bytes memory) {

--- a/src/AndromedaForge.sol
+++ b/src/AndromedaForge.sol
@@ -8,7 +8,7 @@ import {IAndromeda} from "src/IAndromeda.sol";
 interface Vm {
     function ffi(string[] calldata commandInput) external view returns (bytes memory result);
     function setEnv(string calldata name, string calldata value) external;
-    function envOr(string calldata key, bytes32 defaultValue) external returns (bytes32 value);
+    function envOr(string calldata key, bytes memory defaultValue) external returns (bytes memory value);
 }
 
 contract AndromedaForge is IAndromeda {
@@ -57,10 +57,10 @@ contract AndromedaForge is IAndromeda {
         vm.setEnv(env, iToHex(abi.encodePacked(value)));
     }
 
-    function volatileGet(bytes32 tag) public returns (bytes32) {
+    function volatileGet(bytes32 tag) public returns (bytes memory) {
         address caller = msg.sender;
         string memory env = toEnv(activeHost, caller, tag);
-        return vm.envOr(env, bytes32(""));
+        return vm.envOr(env, bytes(""));
     }
 
     // Currently active host

--- a/src/AndromedaRemote.sol
+++ b/src/AndromedaRemote.sol
@@ -17,7 +17,7 @@ import {V3Parser} from "automata-dcap-v3-attestation/lib/QuoteV3Auth/V3Parser.so
 interface Vm {
     function ffi(string[] calldata commandInput) external view returns (bytes memory result);
     function setEnv(string calldata name, string calldata value) external;
-    function envOr(string calldata key, bytes32 defaultValue) external returns (bytes32 value);
+    function envOr(string calldata key, bytes memory defaultValue) external returns (bytes memory value);
     function readFile(string calldata path) external view returns (string memory data);
     function prank(address caller) external;
     function parseJson(string memory json, string memory key) external view;
@@ -139,10 +139,10 @@ contract AndromedaRemote is IAndromeda, DcapDemo {
         vm.setEnv(env, iToHex(abi.encodePacked(value)));
     }
 
-    function volatileGet(bytes32 tag) public returns (bytes32) {
+    function volatileGet(bytes32 tag) public returns (bytes memory) {
         address caller = msg.sender;
         string memory env = toEnv(activeHost, caller, tag);
-        return vm.envOr(env, bytes32(""));
+        return vm.envOr(env, bytes(""));
     }
 
     function doHTTPRequest(IAndromeda.HttpRequest memory) external pure returns (bytes memory) {

--- a/src/IAndromeda.sol
+++ b/src/IAndromeda.sol
@@ -8,7 +8,7 @@ interface IAndromeda is IHash {
     function attestSgx(bytes32 appData) external returns (bytes memory);
     function verifySgx(address caller, bytes32 appData, bytes memory att) external view returns (bool);
     function volatileSet(bytes32 tag, bytes32 value) external;
-    function volatileGet(bytes32 tag) external returns (bytes32);
+    function volatileGet(bytes32 tag) external returns (bytes memory);
     function localRandom() external view returns (bytes32);
     function sealingKey(bytes32 tag) external view returns (bytes32);
 

--- a/src/KeyManager.sol
+++ b/src/KeyManager.sol
@@ -144,11 +144,10 @@ contract KeyManager_v0 is KeyManagerBase {
     mapping(address => bytes) public ciphertexts;
 
     function offchain_Register() public returns (address addr, bytes memory myPub, bytes memory att) {
-        require(keccak256(registry[addr]) == keccak256(bytes("")));
-
         bytes32 myPriv = Suave.sealingKey("myPriv");
         myPub = PKE.derivePubKey(myPriv);
         addr = address(Secp256k1.deriveAddress(uint256(myPriv)));
+        require(keccak256(registry[addr]) == keccak256(bytes("")));
         att = Suave.attestSgx(keccak256(abi.encodePacked("myPub", myPub, addr)));
         return (addr, myPub, att);
     }

--- a/src/KeyManager.sol
+++ b/src/KeyManager.sol
@@ -90,11 +90,29 @@ contract KeyManager_v0 is KeyManagerBase {
         return _derivedPriv(msg.sender);
     }
 
-    function getSeed() private returns (bytes32) {
-        return Suave.volatileGet("seed");
+    function getSeed() internal returns (bytes32) {
+        bytes32 seed = Suave.volatileGet("seed");
+        // check if a seed was lost due a kettle restart and restore it
+        if(seed == bytes32(0)) {
+            seed = recoverSeed();
+        }
+        return seed;
     }
 
-    function setSeed(bytes32 seed) private {
+    function recoverSeed() internal returns (bytes32) {
+        bytes32 myPriv = Suave.sealingKey("myPriv");
+        address addr = address(Secp256k1.deriveAddress(uint256(myPriv)));
+        // make sure that the kettle was onboarded
+        require(keccak256(ciphertexts[addr]) != keccak256(bytes("")));
+        /* TODO: followup: discover ways to restore the seed in case the sealing key is revoked or rotated
+            In this case, a need seed should be generated and everything that was encrypted or keys derived from the old seed should be re-encrypted or re-derived
+            Problem: the decryption here would fail and the execution will be interrupted due to wrong(new) private key */
+        bytes32 seed = abi.decode(PKE.decrypt(myPriv, ciphertexts[addr]), (bytes32));
+        setSeed(seed);
+        return seed;
+    }
+
+    function setSeed(bytes32 seed) internal {
         Suave.volatileSet("seed", seed);
     } 
 
@@ -122,6 +140,8 @@ contract KeyManager_v0 is KeyManagerBase {
     // 2. New node register phase
     // Mapping to nonzero indicates valid Kettle
     mapping(address => bytes) registry;
+    // Mapping kettles to their ciphertexts
+    mapping(address => bytes) public ciphertexts;
 
     function offchain_Register() public returns (address addr, bytes memory myPub, bytes memory att) {
         require(keccak256(registry[addr]) == keccak256(bytes("")));
@@ -150,6 +170,7 @@ contract KeyManager_v0 is KeyManagerBase {
 
     function onchain_Onboard(address addr, bytes memory ciphertext) public {
         // Note: nothing guarantees all ciphertexts on chain are valid
+        ciphertexts[addr] = ciphertext;
         emit Onboard(addr, ciphertext);
     }
 
@@ -159,5 +180,24 @@ contract KeyManager_v0 is KeyManagerBase {
         bytes32 _xPriv = bip32.newFromSeed(abi.encodePacked(seed)).key;
         require(Secp256k1.deriveAddress(uint256(_xPriv)) == xPub);
         setSeed(seed);
+    }
+}
+
+/* This contract is used for testing purposes and should never be used in production
+    It is used to expose the seed and restart and recovery functions for testing purposes 
+*/
+contract TestRecoverableKeyManagerWrapper is KeyManager_v0 {
+    constructor(address _Suave) KeyManager_v0(_Suave) {}
+
+    function getRecoveredSeed() public returns (bytes32) {
+        return super.getSeed();
+    }
+
+    function getCurrentSeed() public returns (bytes32) {
+        return Suave.volatileGet("seed");
+    }
+
+    function restartKettle() public {
+        super.setSeed(bytes32(0));
     }
 }

--- a/src/KeyManager.sol
+++ b/src/KeyManager.sol
@@ -91,12 +91,13 @@ contract KeyManager_v0 is KeyManagerBase {
     }
 
     function getSeed() internal returns (bytes32) {
-        bytes32 seed = Suave.volatileGet("seed");
+        bytes memory seed = Suave.volatileGet("seed");
         // check if a seed was lost due a kettle restart and restore it
-        if(seed == bytes32(0)) {
-            seed = recoverSeed();
+        if(seed.length > 0) {
+            require(seed.length == 32, "Seed length is not 32 bytes");
+            return bytes32(seed);
         }
-        return seed;
+        return recoverSeed();
     }
 
     function recoverSeed() internal returns (bytes32) {
@@ -189,11 +190,11 @@ contract TestRecoverableKeyManagerWrapper is KeyManager_v0 {
     constructor(address _Suave) KeyManager_v0(_Suave) {}
 
     function getRecoveredSeed() public returns (bytes32) {
-        return super.getSeed();
+        return super.recoverSeed();
     }
 
     function getCurrentSeed() public returns (bytes32) {
-        return Suave.volatileGet("seed");
+        return bytes32(Suave.volatileGet("seed"));
     }
 
     function restartKettle() public {

--- a/src/examples/SpeedrunAuction.sol
+++ b/src/examples/SpeedrunAuction.sol
@@ -66,7 +66,10 @@ contract KeyManager {
 
     // Private key will only be accessible in confidential mode
     function xPriv() internal returns (bytes32) {
-        return Suave.volatileGet("xPriv");
+        bytes memory _xPriv = Suave.volatileGet("xPriv");
+        require(_xPriv.length == 32, "Seed length is not 32 bytes");
+        return bytes32(_xPriv);
+        
     }
 
     // To initialize the key, some kettle must call this...

--- a/test/AndromedaForge.t.sol
+++ b/test/AndromedaForge.t.sol
@@ -44,18 +44,18 @@ contract AndromedaForgeTest is Test {
         bytes32 value = keccak256(abi.encodePacked("hi"));
 
         // Initially it is 0
-        bytes32 value2 = andromeda.volatileGet(bytes32("test"));
+        bytes32 value2 = bytes32(andromeda.volatileGet(bytes32("test")));
         assertEq(value2, "");
 
         // After setting it is hash("hi")
         andromeda.volatileSet(bytes32("test"), value);
-        bytes32 value3 = andromeda.volatileGet(bytes32("test"));
+        bytes32 value3 = bytes32(andromeda.volatileGet(bytes32("test")));
         assertEq(value3, value);
 
         // Setting again overwrites
         bytes32 v2 = keccak256("asdf");
         andromeda.volatileSet(bytes32("test"), v2);
-        bytes32 v2check = andromeda.volatileGet(bytes32("test"));
+        bytes32 v2check = bytes32(andromeda.volatileGet(bytes32("test")));
         assertEq(v2check, v2);
     }
 }


### PR DESCRIPTION
In this PR we tackle the issue of losing the seed that generates the private key upon a kettle restart.
Here we rely on the bootstraping and onboarding steps to keep the exchanged ciphertext of the seed onchain.
This way, upon deriving the private key, if kettle has restarted, it will be detected that the seed is not there and initiates the recovery process.
A follow up task would be to discover ways to tackle sealing key revocation and renewals.

Note: this PR relies on the refactoring of volatileGet precompile in this [PR](https://github.com/flashbots/suave-andromeda-revm/pull/16/files)


This PR adds the following:
1- seed recovery proccess
2- fix a minor bug in the offchain registry function (the address checking was wrongly placed)
3- Add unit tests to check the validity of the seed recovery process
4- Modify the kettle-bootstrap.ts script to do the registration and onboarding to enable seed recovery functionality
5- Refactors the Andromeda interface to use the volatileGet updated version from this [PR](https://github.com/flashbots/suave-andromeda-revm/pull/16/files)