### PR TITLE
Adds automatic contract verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ format:
 deploy: build
 	npx ts-node -T scripts/deploy.ts
 
+.PHONY: verify-contracts
+verify-contracts: build deploy
+	npx ts-node -T scripts/verify_contracts.ts
+
 .PHONY: bootstrap
 bootstrap: build
 	npx ts-node -T scripts/bootstrap_kettle.ts

--- a/demos/README.md
+++ b/demos/README.md
@@ -13,9 +13,15 @@ You can see the live demo at `http://timelock.sirrah.suave.flashbots.net:5173`.
 
 Running the Timelock demo webapp requires that you have the Timelock contract address configured in the [../deployment.json](../deployment.json) file like so:
 ```
-  "ADDR_OVERRIDES": {
-    "out/Timelock.sol/Timelock.json": "0x6858162E579DFC66a623AE1bA357d67BF026dDD6",
-    "out/RedisConfidentialStore.sol/BundleConfidentialStore.json": "0xF1b9942f1DBf1dD9538FC2ee8e2FC533b7070366"
+  "ARTIFACTS": {
+    "out/Timelock.sol/Timelock.json": {
+      "address": "0x6858162E579DFC66a623AE1bA357d67BF026dDD6",
+      "constructor_args": []
+    },
+    "out/RedisConfidentialStore.sol/BundleConfidentialStore.json": {
+      "address": "0xF1b9942f1DBf1dD9538FC2ee8e2FC533b7070366",
+      "constructor_args": []
+    }
   }
 ```
 

--- a/demos/common/Contracts.tsx
+++ b/demos/common/Contracts.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 
 import { getContract } from "viem";
-import * as LocalConfig from "../../deployment.json";
 
 import { format_explorer_link } from "./ConsoleLog";
 
@@ -56,7 +55,6 @@ export function ConnectContract(
       return;
     }
     // Create contract instance
-    const ADDR_OVERRIDES: { [key: string]: any } = LocalConfig.ADDR_OVERRIDES;
     const contractInstance = getContract({
       address: addr,
       abi: contract.abi,

--- a/demos/confstore/src/App.tsx
+++ b/demos/confstore/src/App.tsx
@@ -17,7 +17,7 @@ import {
   http,
 } from "viem";
 import * as LocalConfig from "../../../deployment.json";
-import { kettle_advance, kettle_execute } from "../../../scripts/common.ts";
+import { artifact_addr, kettle_advance, kettle_execute } from "../../../scripts/common.ts";
 import StoreContract from "../../../out/RedisConfidentialStore.sol/BundleConfidentialStore.json";
 
 import { Provider } from "../../common/Suave";
@@ -36,7 +36,7 @@ function ConnectStoreContract(suaveProvider, suaveWallet, updateConsoleLog) {
     suaveProvider,
     suaveWallet,
     StoreContract,
-    LocalConfig.ADDR_OVERRIDES[LocalConfig.BUNDLE_STORE_ARTIFACT],
+    artifact_addr(LocalConfig.BUNDLE_STORE_ARTIFACT),
     updateConsoleLog,
   );
 }

--- a/demos/timelock/src/App.tsx
+++ b/demos/timelock/src/App.tsx
@@ -17,7 +17,7 @@ import {
   http,
 } from "viem";
 import * as LocalConfig from "../../../deployment.json";
-import { kettle_advance, kettle_execute } from "../../../scripts/common.ts";
+import { artifact_addr, kettle_advance, kettle_execute } from "../../../scripts/common.ts";
 import Timelock from "../../../out/Timelock.sol/Timelock.json";
 
 import { Provider } from "../../common/Suave";
@@ -36,7 +36,7 @@ function TimelockContract(suaveProvider, suaveWallet, updateConsoleLog) {
     suaveProvider,
     suaveWallet,
     Timelock,
-    LocalConfig.ADDR_OVERRIDES[LocalConfig.TIMELOCK_ARTIFACT],
+    artifact_addr(LocalConfig.TIMELOCK_ARTIFACT),
     updateConsoleLog,
   );
 }

--- a/deployment.json
+++ b/deployment.json
@@ -9,7 +9,7 @@
   "HTTPCALL_ARTIFACT": "out/httpcall.sol/HTTP.json",
   "TRUSTED_MRENCLAVES": [
     "0x2c2facadbb86dfc9989f28b09ca142e3447ad682e00384d2f4611cf690dbab61",
-    "0xbcfbf5f9522b2390005704ec3a672a83f73ffbe143b0c179ca7c4f741633a4cc"
+    "0xbac927cb42088a9bf87719e157f891cc23b422f5e1ddaa21988c43c65449093b"
   ],
   "TRUSTED_MRSIGNERS": [
     "0xf0365ce7081fda379914c703fe08648db1cce3747e8c10f74ff742926399f15a",
@@ -20,5 +20,7 @@
   "TIMELOCK_ARTIFACT": "out/Timelock.sol/Timelock.json",
   "BUNDLE_STORE_ARTIFACT": "out/RedisConfidentialStore.sol/BundleConfidentialStore.json",
   "ADDR_OVERRIDES": {
+  },
+  "CONSTRUCTOR_ARGS": {
   }
 }

--- a/deployment.json
+++ b/deployment.json
@@ -19,8 +19,5 @@
   "SEALED_AUCTION_ARTIFACT": "out/Auction.sol/SealedAuction.json",
   "TIMELOCK_ARTIFACT": "out/Timelock.sol/Timelock.json",
   "BUNDLE_STORE_ARTIFACT": "out/RedisConfidentialStore.sol/BundleConfidentialStore.json",
-  "ADDR_OVERRIDES": {
-  },
-  "CONSTRUCTOR_ARGS": {
-  }
+  "ARTIFACTS": {}
 }

--- a/scripts/bootstrap_kettle.ts
+++ b/scripts/bootstrap_kettle.ts
@@ -2,7 +2,7 @@ import net from "net";
 
 import { ethers, JsonRpcProvider } from "ethers";
 
-import { connect_kettle, attach_artifact, deploy_artifact, kettle_execute, kettle_advance} from "./common"
+import { artifact_addr, connect_kettle, attach_artifact, deploy_artifact, kettle_execute, kettle_advance} from "./common"
 
 import * as LocalConfig from '../deployment.json'
 
@@ -15,7 +15,7 @@ async function main() {
   const wallet = new ethers.Wallet(LocalConfig.PRIVATE_KEY, provider);
 
   /* Assumes andromeda is configured, might not be */
-  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, LocalConfig.ADDR_OVERRIDES[LocalConfig.ANDROMEDA_ARTIFACT]);
+  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, artifact_addr(LocalConfig.ANDROMEDA_ARTIFACT));
   const [KM, _] = await deploy_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, Andromeda.target);
 
   let keyManagerPub = await KM.xPub();

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -7,23 +7,15 @@ import * as LocalConfig from '../deployment.json';
 
 /* Utility functions */
 
-export function artifacts(path: string): {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} {
+export function artifacts(): {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} {
   let ARTIFACTS: {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} = LocalConfig.ARTIFACTS;
   return ARTIFACTS;
 }
 
 export function artifact_addr(path: string): string|null {
-  let ARTIFACTS: {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} = LocalConfig.ARTIFACTS;
-  if (path in ARTIFACTS) {
-    return ARTIFACTS[path]["address"];
-  }
-  return null
-}
-
-export function artifact_constructor_args(path: string): any[] {
-  let ARTIFACTS: {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} = LocalConfig.ARTIFACTS;
-  if (path in ARTIFACTS) {
-    return ARTIFACTS[path]["constructor_args"];
+  let all_artifacts = artifacts();
+  if (path in all_artifacts) {
+    return all_artifacts[path]["address"];
   }
   return null
 }

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -34,7 +34,7 @@ export async function deploy_artifact_direct(path: string, signer: ethers.Signer
 }
 
 export async function deploy_artifact(path: string, signer: ethers.Signer, ...args: any[]): Promise<[ethers.Contract, boolean]> {
-  let ARTIFACTS: {[key: string]: {[key: string]: {"address": string, "constructor_args": any[]}}} = LocalConfig.ARTIFACTS;
+  let ARTIFACTS = artifacts();
   if (path in ARTIFACTS) {
     const addr = ARTIFACTS[path]["address"];
     // TODO: we could force redeployment if constructor args changed

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -31,10 +31,14 @@ export async function deploy_artifact(path: string, signer: ethers.Signer, ...ar
   }
   const contract = await deploy_artifact_direct(path, signer, ...args);
 
+  let CONSTRUCTOR_ARGS: {[key: string]: any} = LocalConfig.CONSTRUCTOR_ARGS;
+  CONSTRUCTOR_ARGS[path] = args;
+
   ADDR_OVERRIDES[path] = contract.target;
   let updatedConfig = {
     ...LocalConfig,
     ADDR_OVERRIDES,
+    CONSTRUCTOR_ARGS,
   };
   delete updatedConfig.default;
 

--- a/scripts/configure_tcbinfo.ts
+++ b/scripts/configure_tcbinfo.ts
@@ -3,7 +3,7 @@ import { ethers, JsonRpcProvider } from "ethers";
 
 import { TCBInfoStruct } from "lib/automata-dcap-v3-attestation/typechain-types/contracts/AutomataDcapV3Attestation";
 
-import { attach_artifact } from "./common.ts"
+import { artifact_addr, attach_artifact } from "./common.ts"
 
 import * as LocalConfig from '../deployment.json'
 
@@ -17,7 +17,7 @@ async function main() {
   const provider = new JsonRpcProvider(LocalConfig.RPC_URL);
   const wallet = new ethers.Wallet(LocalConfig.PRIVATE_KEY, provider);
 
-  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, LocalConfig.ADDR_OVERRIDES[LocalConfig.ANDROMEDA_ARTIFACT]);
+  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, artifact_addr(LocalConfig.ANDROMEDA_ARTIFACT));
 
   for (const tcbInfoFile in tcbInfoFiles) {
     const tcbInfo = JSON.parse(fs.readFileSync(tcbInfoFiles[tcbInfoFile], 'utf8')) as TCBInfoStruct.TCBInfoStruct.tcbInfo;

--- a/scripts/deploy_examples.ts
+++ b/scripts/deploy_examples.ts
@@ -2,7 +2,7 @@ import net from "net";
 
 import { ethers, JsonRpcProvider } from "ethers";
 
-import { connect_kettle, deploy_artifact, deploy_artifact_direct, attach_artifact, kettle_advance, kettle_execute, derive_key } from "./common"
+import { artifact_addr, connect_kettle, deploy_artifact, deploy_artifact_direct, attach_artifact, kettle_advance, kettle_execute, derive_key } from "./common"
 
 import * as LocalConfig from '../deployment.json'
 
@@ -11,8 +11,7 @@ async function deploy() {
 
   const provider = new JsonRpcProvider(LocalConfig.RPC_URL);
   const wallet = new ethers.Wallet(LocalConfig.PRIVATE_KEY, provider);
-  const ADDR_OVERRIDES: {[key: string]: string} = LocalConfig.ADDR_OVERRIDES;
-  const KM = await attach_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, ADDR_OVERRIDES[LocalConfig.KEY_MANAGER_SN_ARTIFACT]);
+  const KM = await attach_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, artifact_addr(LocalConfig.KEY_MANAGER_SN_ARTIFACT));
 
   const [HttpCall, _] = await deploy_artifact(LocalConfig.HTTPCALL_ARTIFACT, wallet);
   const [BundleStore, foundBS] = await deploy_artifact(LocalConfig.BUNDLE_STORE_ARTIFACT, wallet, KM.target, []);

--- a/scripts/onboard_kettle.ts
+++ b/scripts/onboard_kettle.ts
@@ -2,7 +2,7 @@ import net from "net";
 
 import { ethers, JsonRpcProvider } from "ethers";
 
-import { attach_artifact, deploy_artifact, kettle_execute, kettle_advance} from "./common.ts"
+import { artifact_addr, attach_artifact, deploy_artifact, kettle_execute, kettle_advance} from "./common.ts"
 
 import * as LocalConfig from '../deployment.json'
 
@@ -13,7 +13,7 @@ async function main() {
   const wallet = new ethers.Wallet(LocalConfig.PRIVATE_KEY, provider);
 
   /* Assumes andromeda is configured, might not be */
-  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, LocalConfig.ADDR_OVERRIDES[LocalConfig.ANDROMEDA_ARTIFACT]);
+  const Andromeda = await attach_artifact(LocalConfig.ANDROMEDA_ARTIFACT, wallet, artifact_addr(LocalConfig.ANDROMEDA_ARTIFACT));
 
   const [KM, _] = await deploy_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, Andromeda.target);
 

--- a/scripts/test_examples.ts
+++ b/scripts/test_examples.ts
@@ -92,6 +92,7 @@ async function deploy() {
   await kettle_advance(kettle);
   if (!foundTL) {
     await derive_key(await Timelock.getAddress(), kettle, KM);
+    await kettle_advance(kettle);
   }
   await testTL(Timelock, kettle);
 

--- a/scripts/test_examples.ts
+++ b/scripts/test_examples.ts
@@ -2,7 +2,7 @@ import net from "net";
 
 import { ethers, JsonRpcProvider } from "ethers";
 
-import { connect_kettle, deploy_artifact, deploy_artifact_direct, attach_artifact, kettle_advance, kettle_execute, derive_key } from "./common"
+import { artifact_addr, connect_kettle, deploy_artifact, deploy_artifact_direct, attach_artifact, kettle_advance, kettle_execute, derive_key } from "./common"
 
 import * as LocalConfig from '../deployment.json'
 
@@ -80,8 +80,7 @@ async function deploy() {
   await kettle_advance(kettle);
   const provider = new JsonRpcProvider(LocalConfig.RPC_URL);
   const wallet = new ethers.Wallet(LocalConfig.PRIVATE_KEY, provider);
-  const ADDR_OVERRIDES: {[key: string]: string} = LocalConfig.ADDR_OVERRIDES;
-  const KM = await attach_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, ADDR_OVERRIDES[LocalConfig.KEY_MANAGER_SN_ARTIFACT]);
+  const KM = await attach_artifact(LocalConfig.KEY_MANAGER_SN_ARTIFACT, wallet, artifact_addr(LocalConfig.KEY_MANAGER_SN_ARTIFACT));
 
   const [HttpCall, _] = await deploy_artifact(LocalConfig.HTTPCALL_ARTIFACT, wallet);
   await kettle_advance(kettle);

--- a/scripts/verify_contracts.ts
+++ b/scripts/verify_contracts.ts
@@ -2,20 +2,21 @@ import * as LocalConfig from '../deployment.json'
 
 import { execSync } from "child_process";
 
+import { artifacts } from "./common.ts";
+
 function verify_contract(constructor_args, contract_addr, contract_name) {
   let cmd = "forge v --verifier blockscout --verifier-url https://explorer.rigil.suave.flashbots.net/api"+(constructor_args.length > 0? " --constructor-args "+constructor_args.join(","):"")+" "+contract_addr+" "+contract_name+" --compiler-version v0.8.19";
   console.log("Running ", cmd);
-  let o = execSync(cmd);
+  execSync(cmd);
 }
 
 async function verify_all() {
-  Object.keys(LocalConfig).filter(key => key.endsWith("ARTIFACT")).filter(key => LocalConfig["ADDR_OVERRIDES"][LocalConfig[key]]).filter(key => LocalConfig["CONSTRUCTOR_ARGS"][LocalConfig[key]]).forEach(key => {
-    let artifact_addr = LocalConfig["ADDR_OVERRIDES"][LocalConfig[key]];
-    let artifact_path = LocalConfig[key];
+  let all_artifacts = artifacts();
+  Object.keys(all_artifacts).forEach(artifact_path => {
+    let artifact = all_artifacts[artifact_path];
     let artifact_name = artifact_path.match(/([^\/]*).json/)[1];
-    let constructor_args = LocalConfig["CONSTRUCTOR_ARGS"][LocalConfig[key]];
-    console.log("Verifying the following: ", (constructor_args, artifact_addr, artifact_name));
-    verify_contract(constructor_args, artifact_addr, artifact_name);
+    console.log("Verifying the following: ", (artifact["constructor_args"], artifact["address"], artifact_name));
+    verify_contract(artifact["constructor_args"], artifact["address"], artifact_name);
   });
 }
 

--- a/scripts/verify_contracts.ts
+++ b/scripts/verify_contracts.ts
@@ -1,0 +1,25 @@
+import * as LocalConfig from '../deployment.json'
+
+import { execSync } from "child_process";
+
+function verify_contract(constructor_args, contract_addr, contract_name) {
+  let cmd = "forge v --verifier blockscout --verifier-url https://explorer.rigil.suave.flashbots.net/api"+(constructor_args.length > 0? " --constructor-args "+constructor_args.join(","):"")+" "+contract_addr+" "+contract_name+" --compiler-version v0.8.19";
+  console.log("Running ", cmd);
+  let o = execSync(cmd);
+}
+
+async function verify_all() {
+  Object.keys(LocalConfig).filter(key => key.endsWith("ARTIFACT")).filter(key => LocalConfig["ADDR_OVERRIDES"][LocalConfig[key]]).filter(key => LocalConfig["CONSTRUCTOR_ARGS"][LocalConfig[key]]).forEach(key => {
+    let artifact_addr = LocalConfig["ADDR_OVERRIDES"][LocalConfig[key]];
+    let artifact_path = LocalConfig[key];
+    let artifact_name = artifact_path.match(/([^\/]*).json/)[1];
+    let constructor_args = LocalConfig["CONSTRUCTOR_ARGS"][LocalConfig[key]];
+    console.log("Verifying the following: ", (constructor_args, artifact_addr, artifact_name));
+    verify_contract(constructor_args, artifact_addr, artifact_name);
+  });
+}
+
+verify_all().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/Andromeda.sol
+++ b/src/Andromeda.sol
@@ -33,14 +33,11 @@ contract Andromeda is IAndromeda, DcapDemo {
 
     function attestSgx(bytes32 appData) external override returns (bytes memory) {
         (bool success, bytes memory attestBytes) = ATTEST_ADDR.staticcall(abi.encodePacked(msg.sender, appData));
-        // TODO: enable me
-        // require(success);
+        require(success);
         return attestBytes;
     }
 
     function verifySgx(address caller, bytes32 appData, bytes memory att) public view returns (bool) {
-        return true;
-        /*
         bytes memory userdata = abi.encode(address(this), abi.encodePacked(caller, appData));
         bytes memory userReport = abi.encodePacked(sha256(userdata), uint256(0));
         (,, V3Struct.EnclaveReport memory r,,) = V3Parser.parseInput(att);
@@ -48,7 +45,6 @@ contract Andromeda is IAndromeda, DcapDemo {
             return false;
         }
         return this.verifyAttestation(att);
-         */
     }
 
     function localRandom() external view override returns (bytes32) {


### PR DESCRIPTION
Run `make verify-contracts` and it'll automatically verify all contracts deployed.

Re-enables verification checks that were erroneously committed as commented out